### PR TITLE
Efficiency enhancement + Progress.js failed for streams that not support 'clearLine' method.

### DIFF
--- a/lib/progress.js
+++ b/lib/progress.js
@@ -29,19 +29,26 @@ RollingStick.prototype.start = function () {
 
 RollingStick.prototype.success = function () {
   clearInterval(this.rolling);
-  this.stream.clearLine();
-  this.stream.cursorTo(0);
+  if (this.stream.clearLine) {
+    this.stream.clearLine();
+    this.stream.cursorTo(0);
+  }
   console.log('  ' + this.file + '  ' + filesize(this.fsize) + '  ' + chalk.cyan('\u2714'));
 }
 
 RollingStick.prototype.failed = function () {
   clearInterval(this.rolling);
-  this.stream.clearLine();
-  this.stream.cursorTo(0);
+  if (this.stream.clearLine) {
+    this.stream.clearLine();
+    this.stream.cursorTo(0);
+  }
   console.log('  ' + this.file + '  ' + filesize(this.fsize) + '  ' + chalk.red('\u2718'));
 }
 
 RollingStick.prototype.tick = function () {
+  if (!this.stream.clearLine) {
+    return;
+  }
   this.index = ++this.index % 4;
   this.stream.clearLine();
   this.stream.cursorTo(0);
@@ -79,6 +86,3 @@ BurningBar.prototype.render = function () {
 BurningBar.prototype.failed = function () {
   this.bar.terminate();
 }
-
-
-

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -3,6 +3,7 @@ var path = require('path');
 
 var Promise = require('bluebird');
 var rm = Promise.promisify(require('rimraf'));
+var chalk = require('chalk');
 var debug = require('debug')('sync:sync');
 
 var Git = require('./git');
@@ -34,11 +35,12 @@ Sync.prototype.init = function () {
 
   debug('Sync init')
 
-  if (fs.existsSync(path.join(source, '.sync'))) {
-    return rm(path.join(source, '.sync', 'trash'))
-  } else {
+  if (!fs.existsSync(path.join(source, '.sync'))) {
     fs.mkdirSync(path.join(source, '.sync'));
     return repo.init();
+  }
+  else {
+    return Promise.resolve();
   }
 }
 
@@ -48,18 +50,28 @@ Sync.prototype.exec = function () {
   var source = self.source;
   var oss = self.oss;
 
+  var start = Date.now();
+  var profiler = function(message, promise) {
+        var last = Date.now();
+        promise.then(function() {
+            var end = Date.now();
+            console.log(chalk.grey(message + " takes: " + (end - last) + "ms of " + (end - start) + "ms"));
+        });
+        return promise;
+  }
+
   return self.init()
     //generate trash
     .then(function () {
-      return trash(source);
+      return profiler("Building", trash(source));
     })
     //add to git index
     .then(function () {
-      return repo.add()
+      return profiler("Git add", repo.add());
     })
     //use git status to generate operation queue
     .then(function () {
-      return repo.status()
+      return profiler("Git status", repo.status());
     })
     .then(function (status) {
       var queue = parse(status);
@@ -76,7 +88,7 @@ Sync.prototype.exec = function () {
       return oss.deleteMultiObjects(queue)
     })
     .then(function () {
-      return repo.commit()
+      return profiler("Git commit", repo.commit());
     })
     .then(function () {
       debug('Sync complete!');
@@ -86,4 +98,3 @@ Sync.prototype.exec = function () {
       return Promise.reject(err);
     })
 }
-

--- a/lib/trash.js
+++ b/lib/trash.js
@@ -1,9 +1,13 @@
+var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 
 var ncp = require('ncp').ncp;
 var Promise = require('bluebird');
+var chalk = require('chalk');
 var debug = require('debug')('sync:trash');
+
+var stick = require('./progress').stick;
 
 ncp.limit = 16;
 
@@ -11,20 +15,34 @@ exports = module.exports = generateTrash;
 
 function generateTrash(source) {
   return new Promise(function (resolve, reject) {
+    console.log();
+    console.log('    ' + chalk.cyan('Building sync list:'));
+    console.log();
+    var rollingStick = stick(source, fs.statSync(source).size);
+    rollingStick.start();
+
     ncp(source, path.join(source, '.sync', 'trash'), {
       filter: function (name) {
         var isFiltered = (path.basename(name)[0] !== '.')
-        debug('file name: %s %s', name, isFiltered);
+        debug('file name %s %s', name, isFiltered);
         if (isFiltered) return true;
       },
       rename: function (name) {
         return name + '.~trash'
       },
-      modified: false,
+      clobber: false,
+      modified: true,
       transform: hashFile
     }, function (err) {
-      if (err) reject(err);
-      resolve();
+      if (err) {
+        rollingStick.failed();
+        console.log("Error:" + chalk.red(err));
+        reject(err);
+      }
+      else {
+        rollingStick.success();
+        resolve();
+      }
     })
   })
 }


### PR DESCRIPTION
For larger storage syncronization (my case containes 3.4G file), delete "trash" and recreate md5 signature for all file consumes too much time. I invested into the ncp code and opened options "clobber" and "modified" to utilize the ability to filter the files by comparing the modification time of original file and "trash" file, which reduce "trash" time to 30s in my case.
PS. I add a profiler to show actural cost for every steps.
PS. Important! When I redirect stdout to file, which not support "clearLine" clearly, osync crashes. This request solved this bug.
